### PR TITLE
feat: using httpin for request decoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,13 @@ module github.com/kapetacom/sdk-go-rest-server
 
 go 1.21.6
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/ggicci/httpin v0.16.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
+	github.com/ggicci/owl v0.7.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ggicci/httpin v0.16.0 h1:ZR6RXH1xNWg39xqM33V7iz7PP/GuR7vc3aHa2g5mWo4=
+github.com/ggicci/httpin v0.16.0/go.mod h1:whE/5nx1jCp//UQ6rgNpq2WNxOr9FV0OpxMnQQC0Xvs=
+github.com/ggicci/owl v0.7.0 h1:+AMlCR0AY7j72q7hjtN4pm8VJiikwpROtMgvPnXtuik=
+github.com/ggicci/owl v0.7.0/go.mod h1:TRPWshRwYej6uES//YW5aNgLB370URwyta1Ytfs7KXs=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/labstack/echo/v4 v4.11.4 h1:vDZmA+qNeh1pd/cCkEicDMrjtrnMGQ1QFI9gWN1zGq8=
 github.com/labstack/echo/v4 v4.11.4/go.mod h1:noh7EvLwqDsmh/X/HWKPUl1AjzJrhyptRyEbQJfxen8=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=

--- a/request/request.go
+++ b/request/request.go
@@ -5,13 +5,28 @@ package request
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
 
+	"github.com/ggicci/httpin"
 	"github.com/labstack/echo/v4"
 )
 
+func GetRequetParameters[T any](req *http.Request, param *T) error {
+    y,err := httpin.New(param)
+    if err != nil {
+        return err
+    }
+    v, err := y.Decode(req)
+    if err != nil {
+        return err
+    }
+    k := v.(*T)
+    *param = *k
+    return nil
+}
 // GetBody function takes two arguments: an echo context and a pointer to the return value.
 // It used a JSON decoder to convert the request body into the return value.
 // If the decoding fails, the function returns an error.


### PR DESCRIPTION
This will allow us to use structs as a way to construct a contract on the request API like:
```

type ListUsersInput struct {
	Token    string `in:"header=Authorization"`
	IsMember bool   `in:"query=is_member"`
	AgeRange []int  `in:"query=age_range[],age_range"`
}
```

Make the code the language target generates much cleaner, like this:
```
		e.POST("/tasks/:userid/:id", func(ctx echo.Context) error {
			var err error
			type RequestParameters struct {
				UserId string         `in:"path=userId;required"`
				Id     string         `in:"path=id;required"`
				Task   *entities.Task `in:"body=task;required"`
			}
		
			params := &RequestParameters{}
			err = sdk.GetRequetParameters(ctx, params)
			if err != nil {
				return err
			}
			return serviceInterface.AddTask(ctx, params.UserId, params.Id, params.Task)
		})
```